### PR TITLE
Enable jpg output option

### DIFF
--- a/es5.js
+++ b/es5.js
@@ -46,6 +46,10 @@ var async = require('async'),
                         background = Jimp.rgbaToInt(rgba.r, rgba.g, rgba.b, rgba.a * MAX_HEX),
                         newName = filename + suffix + extension;
 
+                    var MIME = Jimp.MIME_PNG;
+                    if (options.jpg) {
+                        MIME = Jimp.MIME_JPEG;
+                    }
                     if (options.crop) {
                         // print('Applying Crop of ' + options.crop.width + 'x' + options.crop.height + ' at ' + options.crop.x + ',' + options.crop.y);
                         // pxData.copy(rawData, rawPos, pxPos, pxPos + byteWidth);: RangeError: out of range index
@@ -143,7 +147,7 @@ var async = require('async'),
                         print('Setting quality level to ' + options.quality, newName);
                         image.quality(options.quality);
                     }
-                    image.getBuffer(Jimp.MIME_PNG, function (error, buffer) {
+                    image.getBuffer(MIME, function (error, buffer) {
                         self.push(new gutil.File({
                             path: newName,
                             contents: buffer

--- a/index.js
+++ b/index.js
@@ -43,6 +43,10 @@ const async = require('async'),
                         background = Jimp.rgbaToInt(rgba.r, rgba.g, rgba.b, rgba.a * MAX_HEX),
                         newName = filename + suffix + extension;
 
+                    let MIME = Jimp.MIME_PNG;
+                    if (options.jpg) {
+                        MIME = Jimp.MIME_JPEG;
+                    }
                     if (options.crop) {
                         // print('Applying Crop of ' + options.crop.width + 'x' + options.crop.height + ' at ' + options.crop.x + ',' + options.crop.y);
                         // pxData.copy(rawData, rawPos, pxPos, pxPos + byteWidth);: RangeError: out of range index
@@ -140,7 +144,7 @@ const async = require('async'),
                         print(`Setting quality level to ${ options.quality }`, newName);
                         image.quality(options.quality);
                     }
-                    image.getBuffer(Jimp.MIME_PNG, (error, buffer) => {
+                    image.getBuffer(MIME, (error, buffer) => {
                         self.push(new gutil.File({
                             path: newName,
                             contents: buffer


### PR DESCRIPTION
Having output hard coded to png hurts portability when jimp is happy to write to jpg.

This adds an option for jpg output, png remains the default so this shouldn't break anything.