### PR TITLE
Retain the source directory structure when creating new files

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,8 @@ const async = require('async'),
 
             Jimp.read(file.contents).then((image) => {
                 const oldName = path.basename(file.path),
+                    oldDirname = path.dirname(file.path),
+                    oldBase = file.base,
                     extension = path.extname(oldName),
                     filename = path.basename(oldName, extension);
 
@@ -156,7 +158,8 @@ const async = require('async'),
 
                     image.getBuffer(type.mime, (error, buffer) => {
                         self.push(new gutil.File({
-                            path: newName,
+                            base: oldBase,
+                            path: path.resolve(oldDirname, newName),
                             contents: buffer
                         }));
                         return callback(error);


### PR DESCRIPTION
:construction_worker: I don't really know what I'm doing with gulp plugin development, so this may not be the best way to achieve this :construction_worker: but it works for me!

I wanted to use gulp-jimp like so:

```es6
  gulp.src('original_photos/**/*.jpg', {base: 'original_photos'})
    .pipe(jimp({
      '@1x': {
        resize: {width: 500}
      },
      '@2x': {
        resize: {width: 1000}
      }
    }))
    .pipe(gulp.dest('dist/photos'))
```

Given these original files...

```
original_photos/foo/a.jpg
original_photos/bar/b.jpg
```

... I expected this output...

```
dist/photos/foo/a@1x.jpg
dist/photos/foo/a@2x.jpg
dist/photos/bar/b@1x.jpg
dist/photos/bar/b@2x.jpg
```

...but got this:

```
dist/photos/a@1x.jpg
dist/photos/a@2x.jpg
dist/photos/b@1x.jpg
dist/photos/b@2x.jpg
```

Everything gets flattened, which (for me at least) wasn't desirable. Flattening is pretty easy with [gulp-flatten](https://github.com/armed/gulp-flatten) for those cases where it is desirable.

When creating the new files, the plugin wasn't passing through the `base` and `dirname` of the source file, which is necessary if you want to retain the source directory structure in your output. I just added those options.

Cheers for the excellent plugin :smile: 