### PR TITLE
Allows type property to override incoming file extension.

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,14 +25,16 @@ const async = require('async'),
         }
 
         function getMIME (extension, type) {
-            type = type || '';
-            if (extension === '.bmp' || type.toLowerCase() === 'bmp' || type.toLowerCase() === 'bitmap') {
-                return { mime: Jimp.MIME_BMP, extension: '.bmp' };
+            type = type || extension.substr(1);
+
+            switch (type.toLowerCase()) {
+                case 'bmp':
+                    return { mime: Jimp.MIME_BMP, extension: '.bmp' };
+                case 'jpg':
+                    return { mime: Jimp.MIME_JPEG, extension: '.jpg' };
+                default:
+                    return { mime: Jimp.MIME_PNG, extension: '.png' };
             }
-            if (extension === '.jpg' || type.toLowerCase() === 'jpg' || type.toLowerCase() === 'jpeg') {
-                return { mime: Jimp.MIME_JPEG, extension: '.jpg' };
-            }
-            return { mime: Jimp.MIME_PNG, extension: '.png' };
         }
 
         return through2.obj(function (file, encoding, next) {


### PR DESCRIPTION
I found a bug where I was using `gulp.src` to read in JPEGs but I wanted to write them out as PNGs. The existing code would honour the filename's extension over the `type` parameter. This PR changes it so if the `type` property is specified it takes prescience over file extension.